### PR TITLE
YSMOD-504

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -338,7 +338,7 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.69</minimum>
+                                            <minimum>0.70</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/graphql/server/BehandlingQueryResolver.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/graphql/server/BehandlingQueryResolver.kt
@@ -1,5 +1,6 @@
 package no.nav.yrkesskade.saksbehandling.graphql
 
+import DetaljertBehandling
 import graphql.kickstart.tools.GraphQLQueryResolver
 import no.nav.yrkesskade.saksbehandling.graphql.common.model.Page
 import no.nav.yrkesskade.saksbehandling.model.BehandlingEntity
@@ -16,6 +17,10 @@ class BehandlingQueryResolver(
 
     fun hentEgneBehandlinger(page: Page): List<BehandlingEntity> {
         return behandlingService.hentEgneBehandlinger(PageRequest.of(page.page, page.size))
+    }
+
+    fun hentBehandling(behandlingId: Long) : DetaljertBehandling {
+        return behandlingService.hentBehandling(behandlingId)
     }
 
     fun antallBehandlinger() = behandlingService.hentAntallBehandlinger()

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DetaljertBehandling.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DetaljertBehandling.kt
@@ -1,0 +1,25 @@
+import com.expediagroup.graphql.generated.enums.BrukerIdType
+import no.nav.yrkesskade.saksbehandling.model.*
+import java.time.Instant
+
+data class DetaljertBehandling(
+    val behandlingId: Long,
+    val tema: String,
+    val brukerId: String,
+    val brukerIdType: BrukerIdType,
+    val behandlendeEnhet: String?,
+    val saksbehandlingsansvarligIdent: String? = null,
+    val behandlingstype: Behandlingstype,
+    val status: Behandlingsstatus,
+    val behandlingsfrist: Instant,
+    val journalpostId: String,
+    val dokumentkategori: String,
+    val systemreferanse: String,
+    val framdriftsstatus: Framdriftsstatus,
+    val opprettetTidspunkt: Instant,
+    val opprettetAv: String,
+    val endretAv: String? = null,
+    val sak: SakEntity? = null,
+    val behandlingResultater: List<BehandlingsresultatEntity>,
+    val dokumenter: List<DokumentInfo>
+)

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DokumentInfo.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DokumentInfo.kt
@@ -1,0 +1,10 @@
+package no.nav.yrkesskade.saksbehandling.model
+
+import java.time.LocalDateTime
+
+data class DokumentInfo(
+    val tittel: String,
+    val type: String,
+    val opprettetTidspunkt: LocalDateTime,
+    val status: String
+)

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DokumentInfo.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/DokumentInfo.kt
@@ -3,6 +3,7 @@ package no.nav.yrkesskade.saksbehandling.model
 import java.time.LocalDateTime
 
 data class DokumentInfo(
+    val dokumentinfoId: String,
     val tittel: String,
     val type: String,
     val opprettetTidspunkt: LocalDateTime,

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
@@ -38,13 +38,16 @@ class BehandlingService(
         val behandling = behandlingRepository.findById(behandlingId).orElseThrow()
 
         val journalpostResult = safClient.hentOppdatertJournalpost(behandling.journalpostId)
-        val dokumenter = if (journalpostResult != null ) {
-            val journalpost = journalpostResult.journalpost!!
+        val dokumenter = if (journalpostResult?.journalpost?.dokumenter != null) {
+            val journalpost = journalpostResult.journalpost
             journalpost.dokumenter!!.map {
                 val dokument = it!!
-                DokumentInfo(tittel = dokument.tittel.orEmpty(), opprettetTidspunkt = journalpost.datoOpprettet, status = journalpost.journalstatus!!.name, type = journalpost.journalposttype!!.name)
+                val journalstatus = if (journalpost.journalstatus != null) journalpost.journalstatus.name  else "Status ikke satt"
+                val journalposttype = if (journalpost.journalposttype != null) journalpost.journalposttype.name else "Type ikke satt"
+
+                DokumentInfo(tittel = dokument.tittel.orEmpty(), opprettetTidspunkt = journalpost.datoOpprettet, status = journalstatus, type = journalposttype)
             }
-        } else emptyList<DokumentInfo>()
+        } else emptyList()
 
         return DetaljertBehandling(
             behandlingId = behandling.behandlingId,

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
@@ -45,7 +45,7 @@ class BehandlingService(
                 val journalstatus = if (journalpost.journalstatus != null) journalpost.journalstatus.name  else "Status ikke satt"
                 val journalposttype = if (journalpost.journalposttype != null) journalpost.journalposttype.name else "Type ikke satt"
 
-                DokumentInfo(tittel = dokument.tittel.orEmpty(), opprettetTidspunkt = journalpost.datoOpprettet, status = journalstatus, type = journalposttype)
+                DokumentInfo(dokumentinfoId = dokument.dokumentInfoId, tittel = dokument.tittel.orEmpty(), opprettetTidspunkt = journalpost.datoOpprettet, status = journalstatus, type = journalposttype)
             }
         } else emptyList()
 

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingService.kt
@@ -1,7 +1,11 @@
 package no.nav.yrkesskade.saksbehandling.service
 
+import DetaljertBehandling
+import com.expediagroup.graphql.generated.Journalpost
+import no.nav.yrkesskade.saksbehandling.graphql.client.SafClient
 import no.nav.yrkesskade.saksbehandling.model.BehandlingEntity
 import no.nav.yrkesskade.saksbehandling.model.Behandlingsstatus
+import no.nav.yrkesskade.saksbehandling.model.DokumentInfo
 import no.nav.yrkesskade.saksbehandling.repository.BehandlingRepository
 import no.nav.yrkesskade.saksbehandling.security.AutentisertBruker
 import no.nav.yrkesskade.saksbehandling.util.getLogger
@@ -14,7 +18,8 @@ import java.lang.IllegalStateException
 @Service
 class BehandlingService(
     private val autentisertBruker: AutentisertBruker,
-    private val behandlingRepository: BehandlingRepository
+    private val behandlingRepository: BehandlingRepository,
+    private val safClient: SafClient
 ) {
 
     companion object {
@@ -27,6 +32,41 @@ class BehandlingService(
         behandlingRepository.save(behandlingEntity).also {
             logger.info("Lagret behandling med journalpostId ${behandlingEntity.journalpostId} og behandlingId ${behandlingEntity.behandlingId}")
         }
+    }
+
+    fun hentBehandling(behandlingId: Long): DetaljertBehandling {
+        val behandling = behandlingRepository.findById(behandlingId).orElseThrow()
+
+        val journalpostResult = safClient.hentOppdatertJournalpost(behandling.journalpostId)
+        val dokumenter = if (journalpostResult != null ) {
+            val journalpost = journalpostResult.journalpost!!
+            journalpost.dokumenter!!.map {
+                val dokument = it!!
+                DokumentInfo(tittel = dokument.tittel.orEmpty(), opprettetTidspunkt = journalpost.datoOpprettet, status = journalpost.journalstatus!!.name, type = journalpost.journalposttype!!.name)
+            }
+        } else emptyList<DokumentInfo>()
+
+        return DetaljertBehandling(
+            behandlingId = behandling.behandlingId,
+            status = behandling.status,
+            behandlingResultater = behandling.behandlingResultater,
+            tema = behandling.tema,
+            opprettetTidspunkt = behandling.opprettetTidspunkt,
+            saksbehandlingsansvarligIdent = behandling.saksbehandlingsansvarligIdent,
+            opprettetAv = behandling.opprettetAv,
+            sak = behandling.sak,
+            dokumenter = dokumenter,
+            endretAv = behandling.endretAv,
+            behandlendeEnhet = behandling.behandlendeEnhet,
+            behandlingsfrist = behandling.behandlingsfrist,
+            behandlingstype = behandling.behandlingstype,
+            brukerId = behandling.brukerId,
+            brukerIdType = behandling.brukerIdType,
+            dokumentkategori = behandling.dokumentkategori,
+            framdriftsstatus = behandling.framdriftsstatus,
+            journalpostId = behandling.journalpostId,
+            systemreferanse = behandling.systemreferanse
+        )
     }
 
     fun hentBehandlinger(page: Pageable): Page<BehandlingEntity> = behandlingRepository.findAll(page)

--- a/src/main/resources/graphql/client/queries/journalpost.graphql
+++ b/src/main/resources/graphql/client/queries/journalpost.graphql
@@ -8,6 +8,7 @@ query($journalpostId: String!) {
     behandlingstema
     kanal
     dokumenter {
+      dokumentInfoId
       tittel
       brevkode
     }

--- a/src/main/resources/graphql/server/schemas/behandling.graphqls
+++ b/src/main/resources/graphql/server/schemas/behandling.graphqls
@@ -23,6 +23,35 @@ type Behandling {
     sak: Sak
 }
 
+type DetaljertBehandling {
+    behandlingId: ID!,
+    tema: String
+    brukerId: String
+    brukerIdType: String
+    behandlendeEnhet: String
+    saksbehandlingsansvarligIdent: String
+    behandlingstype: String
+    status: String
+    behandlingsfrist: Instant
+    journalpostId: String
+    dokumentkategori: String
+    systemreferanse: String
+    framdriftsstatus: String
+    opprettetTidspunkt: Instant
+    opprettetAv: String
+    endretAv: String
+    sak: Sak
+    behandlingResultater: [String]
+    dokumenter: [DokumentInfo]
+}
+
+type DokumentInfo {
+    tittel: String
+    type: String
+    opprettetTidspunkt: Instant
+    status: String
+}
+
 input Page {
     size: Int
     page: Int
@@ -32,6 +61,7 @@ type Query {
     hentBehandlinger(page: Page!): [Behandling]!
     hentEgneBehandlinger(page: Page!): [Behandling]!
     antallBehandlinger: Int!
+    hentBehandling(behandlingId: ID!): DetaljertBehandling
 }
 
 type Mutation {

--- a/src/main/resources/graphql/server/schemas/behandling.graphqls
+++ b/src/main/resources/graphql/server/schemas/behandling.graphqls
@@ -46,6 +46,7 @@ type DetaljertBehandling {
 }
 
 type DokumentInfo {
+    dokumentinfoId: ID!
     tittel: String
     type: String
     opprettetTidspunkt: Instant

--- a/src/test/kotlin/no/nav/yrkesskade/saksbehandling/fixtures/JournalpostFixtures.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/saksbehandling/fixtures/JournalpostFixtures.kt
@@ -22,6 +22,7 @@ fun gyldigJournalpostMedAktoerId(): com.expediagroup.graphql.generated.journalpo
         behandlingstema = null,
         dokumenter = listOf(
             DokumentInfo(
+                "dokument-test-id",
                 "Melding om yrkesskade eller yrkessykdom som er påført under tjeneste på skip eller under fiske/fangst",
                 "NAV 13-07.08"
             )

--- a/src/test/kotlin/no/nav/yrkesskade/saksbehandling/graphql/BehandlingQueryResolverTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/saksbehandling/graphql/BehandlingQueryResolverTest.kt
@@ -5,6 +5,7 @@ import com.graphql.spring.boot.test.GraphQLTestTemplate
 import no.nav.yrkesskade.saksbehandling.config.GraphQLScalarsConfig
 import no.nav.yrkesskade.saksbehandling.fixtures.genererBehandling
 import no.nav.yrkesskade.saksbehandling.fixtures.genererSak
+import no.nav.yrkesskade.saksbehandling.graphql.client.SafClient
 import no.nav.yrkesskade.saksbehandling.model.Behandlingsstatus
 import no.nav.yrkesskade.saksbehandling.repository.BehandlingRepository
 import no.nav.yrkesskade.saksbehandling.security.AutentisertBruker
@@ -16,6 +17,7 @@ import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
+import java.util.*
 
 @Import(value = [GraphQLScalarsConfig::class, GraphQLConfig::class])
 @GraphQLTest
@@ -50,5 +52,17 @@ class BehandlingQueryResolverTest : AbstractTest() {
         val response = graphQLTestTemplate.postForResource("graphql/hent_egne_behandlinger.graphql")
         assertThat(response.statusCode.is2xxSuccessful).isTrue
         assertThat(response.get("$.data.hentEgneBehandlinger.length()")).isEqualTo("1")
+    }
+
+    @Test
+    fun `hent behandling`() {
+        val behandling = genererBehandling(1, "test", Behandlingsstatus.UNDER_BEHANDLING, genererSak())
+        Mockito.`when`(autentisertBruker.preferredUsername).thenReturn("test")
+        Mockito.`when`(behandlingRepository.findById(any())).thenReturn(Optional.of(behandling))
+
+        val response = graphQLTestTemplate.postForResource("graphql/hent_behandling.graphql")
+        assertThat(response.statusCode.is2xxSuccessful).isTrue
+        assertThat(response.get("$.data.hentBehandling.behandlingId")).isEqualTo("1")
+        assertThat(response.get("$.data.hentBehandling.dokumenter.length()")).isEqualTo("0")
     }
 }

--- a/src/test/kotlin/no/nav/yrkesskade/saksbehandling/graphql/GraphQLConfig.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/saksbehandling/graphql/GraphQLConfig.kt
@@ -1,5 +1,6 @@
 package no.nav.yrkesskade.saksbehandling.graphql
 
+import no.nav.yrkesskade.saksbehandling.graphql.client.SafClient
 import no.nav.yrkesskade.saksbehandling.repository.BehandlingRepository
 import no.nav.yrkesskade.saksbehandling.security.AutentisertBruker
 import no.nav.yrkesskade.saksbehandling.service.BehandlingService
@@ -19,8 +20,11 @@ class GraphQLConfig {
     @MockBean
     lateinit var transactionManager: PlatformTransactionManager
 
+    @MockBean
+    lateinit var safClient: SafClient
+
     @Bean
     fun behandlingService(): BehandlingService {
-        return BehandlingService(autentisertBruker, behandlingRepository)
+        return BehandlingService(autentisertBruker, behandlingRepository, safClient)
     }
 }

--- a/src/test/resources/graphql/hent_behandling.graphql
+++ b/src/test/resources/graphql/hent_behandling.graphql
@@ -1,0 +1,8 @@
+query {
+  hentBehandling(behandlingId: 1) {
+    behandlingId
+    dokumenter {
+        tittel
+    }
+  }
+}


### PR DESCRIPTION
- opprettet query for å hente en detaljert behandling
- utvidet journalpost query til i ta med dokumentinfoId til bruk for REST
- utvidet graphql modellen til å ha en detaljert behandling type og dokumentinfo type