### PR TITLE
CHORE

### DIFF
--- a/.nais/nais.yaml
+++ b/.nais/nais.yaml
@@ -57,7 +57,7 @@ spec:
       claims:
         groups:
           {{#each azure.groups as |group|}}
-             - id: {{group}}
+             - id: {{group.id}}
           {{/each}}
   accessPolicy:
     inbound:


### PR DESCRIPTION
- bruker group.id for å sette korrekte gruppeverdier