### PR TITLE
YSMOD-583

### DIFF
--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/DokarkivClient.kt
@@ -7,6 +7,7 @@ import no.nav.yrkesskade.saksbehandling.util.getLogger
 import no.nav.yrkesskade.saksbehandling.util.getSecureLogger
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.retry.annotation.Retryable
 import org.springframework.stereotype.Component
@@ -14,11 +15,12 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.util.*
 
 @Component
+@Profile("!local")
 class DokarkivClient(
     private val dokarkivWebClient: WebClient,
     private val tokenUtil: TokenUtil,
     @Value("\${spring.application.name}") val applicationName: String
-) : AbstractRestClient("Dokarkiv") {
+) : AbstractRestClient("Dokarkiv"), IDokarkivClient {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -27,7 +29,7 @@ class DokarkivClient(
     }
 
     @Retryable
-    fun ferdigstillJournalpost(journalpostId: String, ferdigstillJournalpostRequest: FerdigstillJournalpostRequest) {
+    override fun ferdigstillJournalpost(journalpostId: String, ferdigstillJournalpostRequest: FerdigstillJournalpostRequest) {
         log.info("Ferdigstiller journalpost $journalpostId")
         logTimingAndWebClientResponseException<Any>("ferdigstillJournalpost") {
             dokarkivWebClient.patch()

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/IDokarkivClient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/IDokarkivClient.kt
@@ -1,0 +1,5 @@
+package no.nav.yrkesskade.saksbehandling.client.dokarkiv
+
+interface IDokarkivClient {
+    fun ferdigstillJournalpost(journalpostId: String, ferdigstillJournalpostRequest: FerdigstillJournalpostRequest)
+}

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/LocalDokarkivClient.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/client/dokarkiv/LocalDokarkivClient.kt
@@ -1,0 +1,17 @@
+package no.nav.yrkesskade.saksbehandling.client.dokarkiv
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+@Component
+@Qualifier("dokarkivClient")
+@Profile("local || integration")
+class LocalDokarkivClient : IDokarkivClient {
+    override fun ferdigstillJournalpost(
+        journalpostId: String,
+        ferdigstillJournalpostRequest: FerdigstillJournalpostRequest
+    ) {
+        return
+    }
+}

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/graphql/server/BehandlingMutationResolver.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/graphql/server/BehandlingMutationResolver.kt
@@ -4,6 +4,7 @@ import graphql.kickstart.tools.GraphQLMutationResolver
 import no.nav.yrkesskade.saksbehandling.graphql.common.model.FerdigstillBehandling
 import no.nav.yrkesskade.saksbehandling.model.BehandlingEntity
 import no.nav.yrkesskade.saksbehandling.model.dto.BehandlingDto
+import no.nav.yrkesskade.saksbehandling.model.dto.FerdigstiltBehandlingDto
 import no.nav.yrkesskade.saksbehandling.service.BehandlingService
 import org.springframework.stereotype.Component
 
@@ -14,7 +15,7 @@ class BehandlingMutationResolver(
 
     fun overtaBehandling(behandlingId: Long) : BehandlingDto = behandlingService.overtaBehandling(behandlingId)
 
-    fun ferdigstillBehandling(ferdigstillBehandling: FerdigstillBehandling) : BehandlingDto = behandlingService.ferdigstillBehandling(ferdigstillBehandling)
+    fun ferdigstillBehandling(ferdigstillBehandling: FerdigstillBehandling) : FerdigstiltBehandlingDto = behandlingService.ferdigstillBehandling(ferdigstillBehandling)
     fun leggTilbakeBehandling(behandlingId: Long) : BehandlingDto = behandlingService.leggTilbakeBehandling(behandlingId)
 
     fun overforBehandlingTilLegacy(behandlingId: Long, avviksgrunn: String): Boolean = behandlingService.overforBehandlingTilLegacy(behandlingId, avviksgrunn)

--- a/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/dto/FerdigstiltBehandlingDto.kt
+++ b/src/main/kotlin/no/nav/yrkesskade/saksbehandling/model/dto/FerdigstiltBehandlingDto.kt
@@ -1,0 +1,6 @@
+package no.nav.yrkesskade.saksbehandling.model.dto
+
+data class FerdigstiltBehandlingDto(
+    val behandling: BehandlingDto,
+    val nesteBehandling: BehandlingDto? = null
+)

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -54,6 +54,14 @@ no.nav.security.jwt:
       cookie_name: auth_token
   client:
     registration:
+      dokarkiv-maskintilmaskin:
+        token-endpoint-url: ${AUTH_SERVER}/token
+        grant-type: client_credentials
+        scope: dokarkiv
+        authentication:
+          client-id: dummy-client-id
+          client-secret: dummy-secret
+          client-auth-method: client_secret_basic
       saf-maskintilmaskin:
         token-endpoint-url: ${AUTH_SERVER}/token
         grant-type: client_credentials

--- a/src/main/resources/graphql/server/schemas/kompys.graphqls
+++ b/src/main/resources/graphql/server/schemas/kompys.graphqls
@@ -31,6 +31,11 @@ type Behandling {
     sak: Sak
 }
 
+type FerdigstiltBehandling {
+    behandling: Behandling!
+    nesteBehandling: Behandling
+}
+
 type DetaljertBehandling {
     behandlingId: ID!,
     tema: String
@@ -112,7 +117,7 @@ type Query {
 
 type Mutation {
     overtaBehandling(behandlingId: ID!): Behandling
-    ferdigstillBehandling(ferdigstillBehandling: FerdigstillBehandling!): Behandling
+    ferdigstillBehandling(ferdigstillBehandling: FerdigstillBehandling!): FerdigstiltBehandling
     leggTilbakeBehandling(behandlingId: ID!): Behandling
     overforBehandlingTilLegacy(behandlingId: ID!, avviksgrunn: String!): Boolean!
 }

--- a/src/test/kotlin/no/nav/yrkesskade/saksbehandling/model/BehandlingEntityFactory.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/saksbehandling/model/BehandlingEntityFactory.kt
@@ -56,12 +56,13 @@ class BehandlingEntityFactory {
         }
         fun enBehandledeEnhet() = faker.regexify("[0-9]{4}")
 
+        fun BehandlingEntity.medBehandlingId(behandlingId: Long) = this.copy(behandlingId = behandlingId)
         fun BehandlingEntity.medUtgaaendeJournalpostId(journalpostId: String) = this.copy(utgaaendeJournalpostId = journalpostId)
         fun BehandlingEntity.medSak(sak: SakEntity) = this.copy(sak = sak)
         fun BehandlingEntity.medStatus(status: Behandlingsstatus) = this.copy(status = status)
         fun BehandlingEntity.medJournalpostId(journalpostId: String) = this.copy(journalpostId = journalpostId)
         fun BehandlingEntity.medBehandlingstype(behandlingstype: Behandlingstype) = this.copy(behandlingstype = behandlingstype)
         fun BehandlingEntity.medFramdriftsstatus(framdriftsstatus: Framdriftsstatus) = this.copy(framdriftsstatus = framdriftsstatus)
-        fun BehandlingEntity.saksbehandlingsansvarligIdent(saksbehandlingsansvarligIdent: String) = this.copy(saksbehandlingsansvarligIdent = saksbehandlingsansvarligIdent)
+        fun BehandlingEntity.medSaksbehandlingsansvarligIdent(saksbehandlingsansvarligIdent: String?) = this.copy(saksbehandlingsansvarligIdent = saksbehandlingsansvarligIdent)
     }
 }

--- a/src/test/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingServiceTest.kt
+++ b/src/test/kotlin/no/nav/yrkesskade/saksbehandling/service/BehandlingServiceTest.kt
@@ -96,7 +96,10 @@ class BehandlingServiceTest : AbstractTest() {
         val behandlinger = behandlingService.hentBehandlinger(Pageable.unpaged())
         assertThat(behandlinger.size).isEqualTo(2)
 
-        val egneBehandlingerPage = behandlingService.hentEgneBehandlinger(page = PageRequest.of(0, 10), behandlingsstatus = Behandlingsstatus.UNDER_BEHANDLING.name)
+        val egneBehandlingerPage = behandlingService.hentEgneBehandlinger(
+            page = PageRequest.of(0, 10),
+            behandlingsstatus = Behandlingsstatus.UNDER_BEHANDLING.name
+        )
         assertThat(egneBehandlingerPage.behandlinger.size).isEqualTo(1)
     }
 
@@ -193,7 +196,8 @@ class BehandlingServiceTest : AbstractTest() {
     @Test
     fun `legg tilbake egen behandling`() {
         Mockito.`when`(autentisertBruker.preferredUsername).thenReturn("test")
-        val behandling = behandlingRepository.save(genererBehandling(1L, "test", Behandlingsstatus.UNDER_BEHANDLING, sak))
+        val behandling =
+            behandlingRepository.save(genererBehandling(1L, "test", Behandlingsstatus.UNDER_BEHANDLING, sak))
         assertThat(behandlingService.hentAntallBehandlinger()).isEqualTo(1)
 
         val lagretBehandling = behandlingService.leggTilbakeBehandling(behandling.behandlingId)
@@ -205,14 +209,17 @@ class BehandlingServiceTest : AbstractTest() {
     @Test
     fun `ferdigstill journalfoeringsbehandling`() {
         Mockito.`when`(autentisertBruker.preferredUsername).thenReturn("test")
-        var behandling = genererBehandling(1L, "test", Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.JOURNALFOERING)
+        var behandling = BehandlingEntityFactory.enBehandling("test").medBehandlingstype(Behandlingstype.JOURNALFOERING)
+            .medStatus(Behandlingsstatus.UNDER_BEHANDLING).medSak(sak)
         behandling = behandlingRepository.save(behandling)
         assertThat(behandling.status).isEqualTo(Behandlingsstatus.UNDER_BEHANDLING)
         assertThat(behandlingService.hentAntallBehandlinger()).isEqualTo(1)
 
         val lagretBehandling = behandlingService.ferdigstillBehandling(FerdigstillBehandling(behandling.behandlingId))
-        assertThat(lagretBehandling.saksbehandlingsansvarligIdent).isEqualTo("test")
-        assertThat(lagretBehandling.status).isEqualTo(Behandlingsstatus.FERDIG.kode)
+        assertThat(lagretBehandling.behandling.saksbehandlingsansvarligIdent).isEqualTo("test")
+        assertThat(lagretBehandling.behandling.status).isEqualTo(Behandlingsstatus.FERDIG.kode)
+        assertThat(lagretBehandling.nesteBehandling?.saksbehandlingsansvarligIdent).isEqualTo("test")
+        assertThat(lagretBehandling.nesteBehandling?.status).isEqualTo(Behandlingsstatus.UNDER_BEHANDLING.kode)
         assertThat(behandlingService.hentAntallBehandlinger()).isEqualTo(2)
         Mockito.verify(dokarkivClient).ferdigstillJournalpost(any(), any())
     }
@@ -220,14 +227,16 @@ class BehandlingServiceTest : AbstractTest() {
     @Test
     fun `ferdigstill veiledingsbehandling`() {
         Mockito.`when`(autentisertBruker.preferredUsername).thenReturn("test")
-        var behandling = genererBehandling(1L, "test", Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.VEILEDNING)
+        var behandling =
+            genererBehandling(1L, "test", Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.VEILEDNING)
         behandling = behandlingRepository.save(behandling)
         assertThat(behandling.status).isEqualTo(Behandlingsstatus.UNDER_BEHANDLING)
         assertThat(behandlingService.hentAntallBehandlinger()).isEqualTo(1)
 
         val lagretBehandling = behandlingService.ferdigstillBehandling(FerdigstillBehandling(behandling.behandlingId))
-        assertThat(lagretBehandling.saksbehandlingsansvarligIdent).isEqualTo("test")
-        assertThat(lagretBehandling.status).isEqualTo(Behandlingsstatus.FERDIG.kode)
+        assertThat(lagretBehandling.behandling.saksbehandlingsansvarligIdent).isEqualTo("test")
+        assertThat(lagretBehandling.behandling.status).isEqualTo(Behandlingsstatus.FERDIG.kode)
+        assertThat(lagretBehandling.nesteBehandling).isNull()
         assertThat(behandlingService.hentAntallBehandlinger()).isEqualTo(1)
         Mockito.verify(dokarkivClient, never()).ferdigstillJournalpost(any(), any())
     }
@@ -294,12 +303,34 @@ class BehandlingServiceTest : AbstractTest() {
     fun `hent aapne behandlinger med behandlingstype journalfoering`() {
         // given
         behandlingRepository.save(genererBehandling(10L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak))
-        behandlingRepository.save(genererBehandling(11L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                11L,
+                null,
+                Behandlingsstatus.IKKE_PAABEGYNT,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
         behandlingRepository.save(genererBehandling(12L, null, Behandlingsstatus.UNDER_BEHANDLING, sak))
-        behandlingRepository.save(genererBehandling(13L, null, Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                13L,
+                null,
+                Behandlingsstatus.UNDER_BEHANDLING,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
 
         // when
-        val behandlingsPage = behandlingService.hentAapneBehandlinger(behandlingsfilter = Behandlingsfilter(behandlingstype = Behandlingstype.JOURNALFOERING.kode, null, null,), page = PageRequest.of(0, 10))
+        val behandlingsPage = behandlingService.hentAapneBehandlinger(
+            behandlingsfilter = Behandlingsfilter(
+                behandlingstype = Behandlingstype.JOURNALFOERING.kode,
+                null,
+                null,
+            ), page = PageRequest.of(0, 10)
+        )
 
         // then
         assertThat(behandlingsPage.behandlinger.size).isEqualTo(2)
@@ -310,12 +341,34 @@ class BehandlingServiceTest : AbstractTest() {
     fun `hent aapne behandlinger med status underBehandling`() {
         // given
         behandlingRepository.save(genererBehandling(10L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak))
-        behandlingRepository.save(genererBehandling(11L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                11L,
+                null,
+                Behandlingsstatus.IKKE_PAABEGYNT,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
         behandlingRepository.save(genererBehandling(12L, null, Behandlingsstatus.UNDER_BEHANDLING, sak))
-        behandlingRepository.save(genererBehandling(13L, null, Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                13L,
+                null,
+                Behandlingsstatus.UNDER_BEHANDLING,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
 
         // when
-        val behandlingsPage = behandlingService.hentAapneBehandlinger(behandlingsfilter = Behandlingsfilter(behandlingstype = null, null, status = Behandlingsstatus.UNDER_BEHANDLING.kode), page = PageRequest.of(0, 10))
+        val behandlingsPage = behandlingService.hentAapneBehandlinger(
+            behandlingsfilter = Behandlingsfilter(
+                behandlingstype = null,
+                null,
+                status = Behandlingsstatus.UNDER_BEHANDLING.kode
+            ), page = PageRequest.of(0, 10)
+        )
 
         // then
         assertThat(behandlingsPage.behandlinger.size).isEqualTo(2)
@@ -326,12 +379,34 @@ class BehandlingServiceTest : AbstractTest() {
     fun `hent aapne behandlinger med dokumentkategori tannlegeerklaering`() {
         // given
         behandlingRepository.save(genererBehandling(10L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak))
-        behandlingRepository.save(genererBehandling(11L, null, Behandlingsstatus.IKKE_PAABEGYNT, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                11L,
+                null,
+                Behandlingsstatus.IKKE_PAABEGYNT,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
         behandlingRepository.save(genererBehandling(12L, null, Behandlingsstatus.UNDER_BEHANDLING, sak))
-        behandlingRepository.save(genererBehandling(13L, null, Behandlingsstatus.UNDER_BEHANDLING, sak, Behandlingstype.JOURNALFOERING))
+        behandlingRepository.save(
+            genererBehandling(
+                13L,
+                null,
+                Behandlingsstatus.UNDER_BEHANDLING,
+                sak,
+                Behandlingstype.JOURNALFOERING
+            )
+        )
 
         // when
-        val behandlingsPage = behandlingService.hentAapneBehandlinger(behandlingsfilter = Behandlingsfilter(behandlingstype = null, dokumentkategori = "enFinKategori", status = null), page = PageRequest.of(0, 10))
+        val behandlingsPage = behandlingService.hentAapneBehandlinger(
+            behandlingsfilter = Behandlingsfilter(
+                behandlingstype = null,
+                dokumentkategori = "enFinKategori",
+                status = null
+            ), page = PageRequest.of(0, 10)
+        )
 
         // then
         assertThat(behandlingsPage.behandlinger.size).isEqualTo(4)

--- a/src/test/resources/graphql/behandling/ferdigstill_behandling.graphql
+++ b/src/test/resources/graphql/behandling/ferdigstill_behandling.graphql
@@ -2,7 +2,9 @@ mutation {
     ferdigstillBehandling(ferdigstillBehandling: {
         behandlingId: 1
     }) {
-        behandlingId,
-        status
+        behandling {
+            behandlingId,
+            status
+        }
     }
 }

--- a/src/test/resources/graphql/behandling/ferdigstill_journalfoering_behandling.graphql
+++ b/src/test/resources/graphql/behandling/ferdigstill_journalfoering_behandling.graphql
@@ -5,7 +5,13 @@ mutation {
             avsender: "012345678910"
         }
     }) {
-        behandlingId,
-        status
+        behandling {
+            behandlingId,
+            status
+        },
+        nesteBehandling {
+            behandlingId,
+            status
+        }
     }
 }


### PR DESCRIPTION
- returnerer ett objekt med gjeldende og neste behandling for ferdigstilt behandling
- dersom det er journalfoering behandling, settes samme saksansvarlig på ny behandling
- fikset lokal kjøring av dokarkiv klient
- fikset tester